### PR TITLE
feat: Implement Role-Based Access Control (RBAC) UI Routing

### DIFF
--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -1,0 +1,14 @@
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+
+export default function AdminDashboardPage() {
+  return (
+    <ProtectedRoute allowedRoles={['ADMIN']}>
+      <div className="p-8">
+        <h1 className="text-2xl font-bold text-slate-900">Admin Dashboard</h1>
+        <p className="mt-2 text-slate-600">
+          Welcome. Manage platform users, roles, and system settings here.
+        </p>
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/src/app/dashboard/doctor/page.tsx
+++ b/src/app/dashboard/doctor/page.tsx
@@ -1,0 +1,14 @@
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+
+export default function DoctorDashboardPage() {
+  return (
+    <ProtectedRoute allowedRoles={['DOCTOR']}>
+      <div className="p-8">
+        <h1 className="text-2xl font-bold text-slate-900">Doctor Dashboard</h1>
+        <p className="mt-2 text-slate-600">
+          Welcome. View patient records and manage consultations here.
+        </p>
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/src/app/dashboard/hospital/page.tsx
+++ b/src/app/dashboard/hospital/page.tsx
@@ -1,0 +1,14 @@
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+
+export default function HospitalDashboardPage() {
+  return (
+    <ProtectedRoute allowedRoles={['HOSPITAL']}>
+      <div className="p-8">
+        <h1 className="text-2xl font-bold text-slate-900">Hospital Dashboard</h1>
+        <p className="mt-2 text-slate-600">
+          Welcome. Manage staff, departments, and institutional records here.
+        </p>
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/src/app/dashboard/patient/page.tsx
+++ b/src/app/dashboard/patient/page.tsx
@@ -1,0 +1,14 @@
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+
+export default function PatientDashboardPage() {
+  return (
+    <ProtectedRoute allowedRoles={['PATIENT']}>
+      <div className="p-8">
+        <h1 className="text-2xl font-bold text-slate-900">Patient Dashboard</h1>
+        <p className="mt-2 text-slate-600">
+          Welcome. Manage your medical records and appointments here.
+        </p>
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Providers } from "@/context/Providers";
+import { Header } from "@/components/navigation/Header";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -33,7 +34,7 @@ export default function RootLayout({
       >
         <Providers>
           <div className="relative flex min-h-screen flex-col">
-            {/* Global Navigation or Progress Bars could go here */}
+            <Header />
             <main className="flex-1">{children}</main>
           </div>
         </Providers>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState } from 'react';
+import { useAuthStore } from '@/store/authStore';
+import { useRoleRedirect } from '@/hooks/useRoleRedirect';
+import api from '@/services/api.service';
+import type { UserRole } from '@/types';
+
+export default function LoginPage() {
+  const { walletAddress, role, setWalletAddress, setRole, setIsLoading } =
+    useAuthStore();
+  const [error, setError] = useState<string | null>(null);
+  const [connecting, setConnecting] = useState(false);
+
+  // Once wallet + role are resolved, redirect automatically
+  useRoleRedirect(walletAddress, role);
+
+  async function handleConnect() {
+    setError(null);
+    setConnecting(true);
+    setIsLoading(true);
+
+    try {
+      // Freighter wallet integration (window.freighter is injected by the extension)
+      const freighter =
+        typeof window !== 'undefined'
+          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (window as any).freighter
+          : null;
+
+      if (!freighter) {
+        setError(
+          'Freighter wallet extension not found. Please install it from https://freighter.app.'
+        );
+        return;
+      }
+
+      const { publicKey } = await freighter.getPublicKey();
+
+      if (!publicKey) {
+        setError('Could not retrieve public key from wallet.');
+        return;
+      }
+
+      setWalletAddress(publicKey);
+
+      // Query the backend to resolve the on-chain role for this wallet
+      const response = await api.get<{ role: UserRole }>(
+        `/users/${publicKey}/role`
+      );
+      setRole(response.data.role);
+    } catch (err: unknown) {
+      // 404 means wallet has no registered role
+      if (
+        typeof err === 'object' &&
+        err !== null &&
+        'response' in err &&
+        (err as { response?: { status?: number } }).response?.status === 404
+      ) {
+        // walletAddress is already set; useRoleRedirect will send to /role-not-registered
+        setRole(null);
+      } else {
+        setError('Failed to connect wallet. Please try again.');
+        setWalletAddress(null);
+        setRole(null);
+      }
+    } finally {
+      setConnecting(false);
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[80vh] text-center px-4">
+      <h1 className="text-3xl font-bold text-slate-900">Connect Your Wallet</h1>
+      <p className="mt-4 text-base text-slate-600 max-w-md">
+        Connect your Freighter wallet to access your role-specific dashboard on
+        the Healthy-Stellar platform.
+      </p>
+
+      {error && (
+        <div
+          role="alert"
+          className="mt-6 rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700 max-w-md"
+        >
+          {error}
+        </div>
+      )}
+
+      <button
+        onClick={handleConnect}
+        disabled={connecting}
+        className="mt-8 rounded-md bg-blue-600 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+      >
+        {connecting ? 'Connecting…' : 'Connect Freighter Wallet'}
+      </button>
+    </div>
+  );
+}

--- a/src/app/role-not-registered/page.tsx
+++ b/src/app/role-not-registered/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Link from 'next/link';
+import { useAuthStore } from '@/store/authStore';
+
+export default function RoleNotRegisteredPage() {
+  const { clearAuth } = useAuthStore();
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[80vh] text-center px-4">
+      <div className="rounded-full bg-yellow-100 p-4 mb-6">
+        <svg
+          className="h-10 w-10 text-yellow-600"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+          />
+        </svg>
+      </div>
+
+      <h1 className="text-3xl font-bold text-slate-900">Role Not Registered</h1>
+      <p className="mt-4 text-base text-slate-600 max-w-md">
+        Your wallet is connected, but no role has been assigned to it on the
+        Healthy-Stellar platform. Please contact the platform administrator to
+        have your role assigned.
+      </p>
+
+      <div className="mt-8 flex flex-col sm:flex-row items-center gap-4">
+        <Link
+          href="/"
+          onClick={clearAuth}
+          className="rounded-md bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+        >
+          Disconnect &amp; Go Home
+        </Link>
+        <a
+          href="mailto:support@healthy-stellar.io"
+          className="text-sm font-semibold text-slate-700 hover:text-slate-900"
+        >
+          Contact Support
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/store/authStore';
+import type { UserRole } from '@/types';
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+  /** The role(s) allowed to access this route. If omitted, any authenticated user is allowed. */
+  allowedRoles?: UserRole[];
+}
+
+/**
+ * Wraps a page to enforce authentication and optional role-based access.
+ * - Unauthenticated visitors are redirected to the home page.
+ * - Authenticated users whose role is not in allowedRoles are redirected to their own dashboard.
+ */
+export function ProtectedRoute({ children, allowedRoles }: ProtectedRouteProps) {
+  const router = useRouter();
+  const { walletAddress, role, isLoading } = useAuthStore();
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    // Not connected → send to home
+    if (!walletAddress) {
+      router.replace('/');
+      return;
+    }
+
+    // Connected but no role → role-not-registered page
+    if (!role) {
+      router.replace('/role-not-registered');
+      return;
+    }
+
+    // Role restriction check
+    if (allowedRoles && !allowedRoles.includes(role)) {
+      // Redirect to their own dashboard instead of a 403
+      const dashboardMap: Record<UserRole, string> = {
+        PATIENT: '/dashboard/patient',
+        DOCTOR: '/dashboard/doctor',
+        HOSPITAL: '/dashboard/hospital',
+        ADMIN: '/dashboard/admin',
+      };
+      router.replace(dashboardMap[role]);
+    }
+  }, [walletAddress, role, isLoading, allowedRoles, router]);
+
+  // While loading or redirecting, render nothing to avoid flash
+  if (isLoading || !walletAddress || !role) {
+    return null;
+  }
+
+  if (allowedRoles && !allowedRoles.includes(role)) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/navigation/Header.tsx
+++ b/src/components/navigation/Header.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import Link from 'next/link';
+import { useAuthStore } from '@/store/authStore';
+import { ROLE_DASHBOARD_MAP } from '@/hooks/useRoleRedirect';
+
+/**
+ * Global header with navigation links conditionally rendered by role.
+ */
+export function Header() {
+  const { walletAddress, role, clearAuth } = useAuthStore();
+
+  const shortAddress = walletAddress
+    ? `${walletAddress.slice(0, 4)}…${walletAddress.slice(-4)}`
+    : null;
+
+  return (
+    <header className="border-b border-slate-200 bg-white">
+      <nav
+        className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6 lg:px-8"
+        aria-label="Global"
+      >
+        {/* Brand */}
+        <Link
+          href="/"
+          className="text-lg font-bold text-blue-600 hover:text-blue-500"
+        >
+          Healthy-Stellar
+        </Link>
+
+        {/* Role-specific nav links */}
+        <div className="flex items-center gap-6 text-sm font-medium text-slate-700">
+          {role === 'PATIENT' && (
+            <>
+              <Link href="/dashboard/patient" className="hover:text-blue-600">
+                My Records
+              </Link>
+              <Link href="/dashboard/patient" className="hover:text-blue-600">
+                Appointments
+              </Link>
+            </>
+          )}
+
+          {role === 'DOCTOR' && (
+            <>
+              <Link href="/dashboard/doctor" className="hover:text-blue-600">
+                Patients
+              </Link>
+              <Link href="/dashboard/doctor" className="hover:text-blue-600">
+                Consultations
+              </Link>
+            </>
+          )}
+
+          {role === 'HOSPITAL' && (
+            <>
+              <Link href="/dashboard/hospital" className="hover:text-blue-600">
+                Staff
+              </Link>
+              <Link href="/dashboard/hospital" className="hover:text-blue-600">
+                Departments
+              </Link>
+            </>
+          )}
+
+          {role === 'ADMIN' && (
+            <>
+              <Link href="/dashboard/admin" className="hover:text-blue-600">
+                Users
+              </Link>
+              <Link href="/dashboard/admin" className="hover:text-blue-600">
+                Settings
+              </Link>
+            </>
+          )}
+
+          {/* Dashboard shortcut for any authenticated user */}
+          {role && (
+            <Link
+              href={ROLE_DASHBOARD_MAP[role]}
+              className="rounded-md bg-blue-50 px-3 py-1.5 text-blue-700 hover:bg-blue-100"
+            >
+              Dashboard
+            </Link>
+          )}
+
+          {/* Auth actions */}
+          {walletAddress ? (
+            <button
+              onClick={clearAuth}
+              className="text-slate-500 hover:text-red-600"
+              title={walletAddress}
+            >
+              {shortAddress} · Disconnect
+            </button>
+          ) : (
+            <Link
+              href="/login"
+              className="rounded-md bg-blue-600 px-3.5 py-2 text-white hover:bg-blue-500"
+            >
+              Connect Wallet
+            </Link>
+          )}
+        </div>
+      </nav>
+    </header>
+  );
+}

--- a/src/hooks/useRoleRedirect.ts
+++ b/src/hooks/useRoleRedirect.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import type { UserRole } from '@/types';
+
+export const ROLE_DASHBOARD_MAP: Record<UserRole, string> = {
+  PATIENT: '/dashboard/patient',
+  DOCTOR: '/dashboard/doctor',
+  HOSPITAL: '/dashboard/hospital',
+  ADMIN: '/dashboard/admin',
+};
+
+/**
+ * Redirects an authenticated user to their role-specific dashboard.
+ * If no role is assigned, redirects to /role-not-registered.
+ */
+export function useRoleRedirect(
+  walletAddress: string | null,
+  role: UserRole | null
+) {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!walletAddress) return;
+
+    if (!role) {
+      router.replace('/role-not-registered');
+      return;
+    }
+
+    router.replace(ROLE_DASHBOARD_MAP[role]);
+  }, [walletAddress, role, router]);
+}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { UserRole } from '@/types';
+
+interface AuthState {
+  walletAddress: string | null;
+  role: UserRole | null;
+  isLoading: boolean;
+  setWalletAddress: (address: string | null) => void;
+  setRole: (role: UserRole | null) => void;
+  setIsLoading: (loading: boolean) => void;
+  clearAuth: () => void;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      walletAddress: null,
+      role: null,
+      isLoading: false,
+      setWalletAddress: (address) => set({ walletAddress: address }),
+      setRole: (role) => set({ role }),
+      setIsLoading: (isLoading) => set({ isLoading }),
+      clearAuth: () => set({ walletAddress: null, role: null, isLoading: false }),
+    }),
+    {
+      name: 'healthy-stellar-auth',
+      // Only persist address and role, not loading state
+      partialize: (state) => ({
+        walletAddress: state.walletAddress,
+        role: state.role,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
Closes #17


- Add Zustand auth store (src/store/authStore.ts) persisting walletAddress and role
- Add useRoleRedirect hook that redirects authenticated users to their role-specific dashboard
- Add ProtectedRoute component that guards pages by role; unauthenticated visitors are sent to home
- Add /login page that connects Freighter wallet and resolves on-chain role via backend API
- Add /role-not-registered page shown when wallet has no assigned role
- Add role-specific dashboard pages: /dashboard/patient, /dashboard/doctor, /dashboard/hospital, /dashboard/admin
- Add Header component with navigation links conditionally rendered by role
- Wire Header into root layout