### PR TITLE
fix: add error handling for wallet connection failures

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,8 +6,9 @@ import { useRouter } from 'next/navigation';
 import {
   Activity, User, Stethoscope, Hospital,
   ChevronRight, ShieldCheck, ArrowLeft, Loader2,
-  CheckCircle2, Wallet
+  CheckCircle2, Wallet, AlertCircle
 } from 'lucide-react';
+import { useToast } from '@/hooks/useToast';
 
 type Role = 'PATIENT' | 'DOCTOR' | 'HOSPITAL';
 
@@ -49,9 +50,12 @@ const trustPoints = [
 
 export default function LoginPage() {
   const router = useRouter();
+  const { toast } = useToast();
   const [step, setStep] = useState<'role' | 'wallet'>('role');
   const [selectedRole, setSelectedRole] = useState<Role | null>(null);
   const [connecting, setConnecting] = useState<string | null>(null);
+  const [connectError, setConnectError] = useState<string | null>(null);
+  const [lastWallet, setLastWallet] = useState<string | null>(null);
 
   function handleRoleSelect(role: Role) {
     setSelectedRole(role);
@@ -60,8 +64,20 @@ export default function LoginPage() {
 
   async function handleWalletConnect(walletId: string) {
     setConnecting(walletId);
-    await new Promise(r => setTimeout(r, 1800));
-    router.push(selectedRole === 'DOCTOR' ? '/dashboard/doctor' : '/dashboard/patient');
+    setConnectError(null);
+    setLastWallet(walletId);
+    try {
+      await new Promise(r => setTimeout(r, 1800));
+      router.push(selectedRole === 'DOCTOR' ? '/dashboard/doctor' : '/dashboard/patient');
+    } catch (err) {
+      const message = err instanceof Error && err.message
+        ? err.message
+        : 'Wallet connection rejected. Please try again.';
+      toast(message, 'error');
+      setConnectError(message);
+    } finally {
+      setConnecting(null);
+    }
   }
 
   return (
@@ -225,6 +241,23 @@ export default function LoginPage() {
               >
                 <ArrowLeft className="w-3.5 h-3.5" /> Back
               </button>
+
+              {connectError && (
+                <div className="flex items-center justify-between rounded-[10px] p-3 mb-4"
+                     style={{ background: 'rgba(248,113,113,0.08)', border: '1px solid rgba(248,113,113,0.2)' }}>
+                  <div className="flex items-center gap-2">
+                    <AlertCircle className="w-3.5 h-3.5 shrink-0 text-red-400" />
+                    <p className="text-xs text-red-400">{connectError}</p>
+                  </div>
+                  <button
+                    onClick={() => lastWallet && handleWalletConnect(lastWallet)}
+                    className="text-xs font-semibold ml-3 shrink-0 transition-colors hover:opacity-80"
+                    style={{ color: '#00C896' }}
+                  >
+                    Retry
+                  </button>
+                </div>
+              )}
 
               <div className="space-y-2.5 mb-5">
                 {wallets.map(wallet => (


### PR DESCRIPTION
Wrap `handleWalletConnect` in a try/catch block, show an error toast with a clear message on failure, and display a retry button so the user can re-attempt the connection without refreshing.

Closes #34