### PR TITLE
feat: add real-time notifications via WebSocket or Server-Sent Events

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -5,9 +5,10 @@ import { usePathname, useRouter } from 'next/navigation';
 import {
   Activity, LayoutDashboard, FileText, Shield,
   Calendar, Clock, Settings, LogOut,
-  Stethoscope, Users, Bell, ChevronDown,
+  Stethoscope, Users, ChevronDown,
   Hospital, ClipboardList, ShieldCheck,
 } from 'lucide-react';
+import NotificationBell from '@/components/navigation/NotificationBell';
 import { useWalletStore } from '@/store/useWalletStore';
 import { useAuthStore } from '@/store/authStore';
 
@@ -200,9 +201,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           </div>
 
           <div className="flex items-center gap-2">
-            <button className="btn-icon rounded-[9px]" aria-label="Notifications">
-              <Bell className="w-4 h-4" />
-            </button>
+            <NotificationBell />
             <div className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold"
                  style={{ background: 'rgba(0,200,150,0.15)', color: '#00C896', border: '1px solid rgba(0,200,150,0.2)' }}>
               {initials}

--- a/src/components/navigation/NotificationBell.tsx
+++ b/src/components/navigation/NotificationBell.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Bell } from 'lucide-react';
+import { useNotifications } from '@/hooks/useNotifications';
+import { useWalletStore } from '@/store/useWalletStore';
+import { useToast } from '@/hooks/useToast';
+import { NotificationEvent } from '@/hooks/useNotifications';
+
+export default function NotificationBell() {
+  const { publicKey } = useWalletStore();
+  const { toast } = useToast();
+
+  const handleNotification = (event: NotificationEvent) => {
+    const typeToKind = {
+      access_request:        'info',
+      appointment_confirmed: 'success',
+      record_shared:         'info',
+    } as const;
+    toast(event.message, typeToKind[event.type] ?? 'info');
+  };
+
+  const { unreadCount, clearUnread } = useNotifications({
+    address: publicKey,
+    onNotification: handleNotification,
+  });
+
+  return (
+    <button
+      className="btn-icon rounded-[9px] relative"
+      aria-label="Notifications"
+      onClick={clearUnread}
+    >
+      <Bell className="w-4 h-4" />
+      {unreadCount > 0 && (
+        <span className="absolute -top-1 -right-1 min-w-[16px] h-4 flex items-center justify-center rounded-full text-[10px] font-bold text-white px-0.5"
+              style={{ background: '#EF4444' }}>
+          {unreadCount > 9 ? '9+' : unreadCount}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useRef, useCallback, useState } from 'react';
+
+export type NotificationEventType = 'access_request' | 'appointment_confirmed' | 'record_shared';
+
+export interface NotificationEvent {
+  id: string;
+  type: NotificationEventType;
+  message: string;
+  timestamp: number;
+}
+
+const EVENT_LABELS: Record<NotificationEventType, string> = {
+  access_request:       'New access request received',
+  appointment_confirmed: 'Appointment confirmed',
+  record_shared:        'A medical record was shared with you',
+};
+
+interface UseNotificationsOptions {
+  address: string | null;
+  onNotification?: (event: NotificationEvent) => void;
+}
+
+export function useNotifications({ address, onNotification }: UseNotificationsOptions) {
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [notifications, setNotifications] = useState<NotificationEvent[]>([]);
+  const esRef = useRef<EventSource | null>(null);
+
+  const clearUnread = useCallback(() => setUnreadCount(0), []);
+
+  useEffect(() => {
+    if (!address || !process.env.NEXT_PUBLIC_API_URL) return;
+
+    const url = `${process.env.NEXT_PUBLIC_API_URL}/notifications/stream?address=${encodeURIComponent(address)}`;
+    const es = new EventSource(url);
+    esRef.current = es;
+
+    const handleEvent = (raw: MessageEvent) => {
+      try {
+        const data = JSON.parse(raw.data) as { type: NotificationEventType; id?: string };
+        const event: NotificationEvent = {
+          id: data.id ?? crypto.randomUUID(),
+          type: data.type,
+          message: EVENT_LABELS[data.type] ?? 'New notification',
+          timestamp: Date.now(),
+        };
+        setNotifications((prev) => [event, ...prev]);
+        setUnreadCount((n) => n + 1);
+        onNotification?.(event);
+      } catch {
+        // malformed event — ignore
+      }
+    };
+
+    (['access_request', 'appointment_confirmed', 'record_shared'] as const).forEach((type) => {
+      es.addEventListener(type, handleEvent);
+    });
+
+    es.onerror = () => {
+      es.close();
+    };
+
+    return () => {
+      es.close();
+      esRef.current = null;
+    };
+  }, [address]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { notifications, unreadCount, clearUnread };
+}


### PR DESCRIPTION
Closes #37

- `useNotifications` hook opens an SSE connection to `/notifications/stream?address=...` on dashboard mount and closes it on unmount
- Handles `access_request`, `appointment_confirmed`, and `record_shared` event types — fires a toast for each
- New `NotificationBell` component replaces the static bell icon in the dashboard header; shows a live unread count badge that resets on click