### PR TITLE
chore: remove unused @soroban-react/core dependency or implement it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "healthy-stellar-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@soroban-react/core": "^9.3.0",
         "@stellar/stellar-sdk": "^14.5.0",
         "@tanstack/react-query": "^5.90.21",
         "axios": "^1.13.5",
@@ -42,19 +41,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@creit.tech/xbull-wallet-connect": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@creit.tech/xbull-wallet-connect/-/xbull-wallet-connect-0.3.0.tgz",
-      "integrity": "sha512-pByi0bTAWd2ZdolVtkXcAU1DYTtz/cJc/IkRUz9x9/1NsFVyrM4UxE8tHgVZ3mwrJ4josoDwYP957ynQw195YQ==",
-      "dependencies": {
-        "rxjs": "^7.5.5",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.1"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -620,12 +606,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@lobstrco/signer-extension-api": {
-      "version": "1.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@lobstrco/signer-extension-api/-/signer-extension-api-1.0.0-beta.0.tgz",
-      "integrity": "sha512-16V34W9MyTgunGvgkzv1JmV+k59OjNWCrNOH+KH+6vWamcGDGBnFhvRgGEarEhINYITMGkdqEvaEy7qTD5s5cw==",
-      "license": "GPL-3.0"
-    },
     "node_modules/@next/env": {
       "version": "15.5.19",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.19.tgz",
@@ -836,203 +816,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@soroban-react/core": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@soroban-react/core/-/core-9.3.0.tgz",
-      "integrity": "sha512-CCXSjPKnhdQi80eL2Vt7vvdzXgJmOQJBpN70rll6I4PXGpwg77f2lxKQaQRmcAkH/OymuXi4AteyzhSbX7nLsg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@soroban-react/freighter": "^9.1.13",
-        "@soroban-react/lobstr": "^9.1.13",
-        "@soroban-react/types": "^9.1.13",
-        "@soroban-react/xbull": "^9.3.0",
-        "@stellar/stellar-sdk": "12.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/@soroban-react/core/node_modules/@stellar/stellar-base": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
-      "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/js-xdr": "^3.1.2",
-        "base32.js": "^0.1.0",
-        "bignumber.js": "^9.1.2",
-        "buffer": "^6.0.3",
-        "sha.js": "^2.3.6",
-        "tweetnacl": "^1.0.3"
-      },
-      "optionalDependencies": {
-        "sodium-native": "^4.1.1"
-      }
-    },
-    "node_modules/@soroban-react/core/node_modules/@stellar/stellar-sdk": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.2.0.tgz",
-      "integrity": "sha512-Wy5sDOqb5JvAC76f4sQIV6Pe3JNyZb0PuyVNjwt3/uWsjtxRkFk6s2yTHTefBLWoR+mKxDjO7QfzhycF1v8FXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/stellar-base": "^12.1.0",
-        "axios": "^1.7.2",
-        "bignumber.js": "^9.1.2",
-        "eventsource": "^2.0.2",
-        "randombytes": "^2.1.0",
-        "toml": "^3.0.0",
-        "urijs": "^1.19.1"
-      }
-    },
-    "node_modules/@soroban-react/freighter": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@soroban-react/freighter/-/freighter-9.1.13.tgz",
-      "integrity": "sha512-a2ZOwYCARRYW/oO5YXGgLXyDhLkkY+fKxlqZ3MxvDIK8XRKVyacd7Rx1r02ZR5CsFe8BMlycZTfenDGPuo3nsQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@soroban-react/types": "^9.1.13",
-        "@stellar/freighter-api": "1.7.1"
-      }
-    },
-    "node_modules/@soroban-react/lobstr": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@soroban-react/lobstr/-/lobstr-9.1.13.tgz",
-      "integrity": "sha512-jItEGMWmhPgGOzUr3zZ2vJHTkGr4wsyptjWJakE6mJj3Z5J+CEqq/+681Td4eQTmPM2p57wqm5YUDibx04Q43A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@lobstrco/signer-extension-api": "^1.0.0-beta.0",
-        "@soroban-react/types": "^9.1.13",
-        "@stellar/stellar-sdk": "12.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/@soroban-react/lobstr/node_modules/@stellar/stellar-base": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
-      "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/js-xdr": "^3.1.2",
-        "base32.js": "^0.1.0",
-        "bignumber.js": "^9.1.2",
-        "buffer": "^6.0.3",
-        "sha.js": "^2.3.6",
-        "tweetnacl": "^1.0.3"
-      },
-      "optionalDependencies": {
-        "sodium-native": "^4.1.1"
-      }
-    },
-    "node_modules/@soroban-react/lobstr/node_modules/@stellar/stellar-sdk": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.2.0.tgz",
-      "integrity": "sha512-Wy5sDOqb5JvAC76f4sQIV6Pe3JNyZb0PuyVNjwt3/uWsjtxRkFk6s2yTHTefBLWoR+mKxDjO7QfzhycF1v8FXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/stellar-base": "^12.1.0",
-        "axios": "^1.7.2",
-        "bignumber.js": "^9.1.2",
-        "eventsource": "^2.0.2",
-        "randombytes": "^2.1.0",
-        "toml": "^3.0.0",
-        "urijs": "^1.19.1"
-      }
-    },
-    "node_modules/@soroban-react/types": {
-      "version": "9.1.13",
-      "resolved": "https://registry.npmjs.org/@soroban-react/types/-/types-9.1.13.tgz",
-      "integrity": "sha512-iba0pzMwGRh216uLGjIsTAwEolJi5qoFXdnZo/0EWY4TvVATMSSs+WrAKccHMgGXntYJJXpUa0xtIbchQ6yiHA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/stellar-sdk": "12.2.0"
-      }
-    },
-    "node_modules/@soroban-react/types/node_modules/@stellar/stellar-base": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
-      "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/js-xdr": "^3.1.2",
-        "base32.js": "^0.1.0",
-        "bignumber.js": "^9.1.2",
-        "buffer": "^6.0.3",
-        "sha.js": "^2.3.6",
-        "tweetnacl": "^1.0.3"
-      },
-      "optionalDependencies": {
-        "sodium-native": "^4.1.1"
-      }
-    },
-    "node_modules/@soroban-react/types/node_modules/@stellar/stellar-sdk": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.2.0.tgz",
-      "integrity": "sha512-Wy5sDOqb5JvAC76f4sQIV6Pe3JNyZb0PuyVNjwt3/uWsjtxRkFk6s2yTHTefBLWoR+mKxDjO7QfzhycF1v8FXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/stellar-base": "^12.1.0",
-        "axios": "^1.7.2",
-        "bignumber.js": "^9.1.2",
-        "eventsource": "^2.0.2",
-        "randombytes": "^2.1.0",
-        "toml": "^3.0.0",
-        "urijs": "^1.19.1"
-      }
-    },
-    "node_modules/@soroban-react/xbull": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@soroban-react/xbull/-/xbull-9.3.0.tgz",
-      "integrity": "sha512-TDhpyeHlS0Zv7AgCO8t9ymH4QkREo3A9lpjVtFQmlO4VvnVm70oTT3U12uARwVpgJrVShaesKIsyhvO20v4K0A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@creit.tech/xbull-wallet-connect": "0.3.0",
-        "@soroban-react/types": "^9.1.13",
-        "@stellar/stellar-sdk": "12.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/@soroban-react/xbull/node_modules/@stellar/stellar-base": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
-      "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/js-xdr": "^3.1.2",
-        "base32.js": "^0.1.0",
-        "bignumber.js": "^9.1.2",
-        "buffer": "^6.0.3",
-        "sha.js": "^2.3.6",
-        "tweetnacl": "^1.0.3"
-      },
-      "optionalDependencies": {
-        "sodium-native": "^4.1.1"
-      }
-    },
-    "node_modules/@soroban-react/xbull/node_modules/@stellar/stellar-sdk": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.2.0.tgz",
-      "integrity": "sha512-Wy5sDOqb5JvAC76f4sQIV6Pe3JNyZb0PuyVNjwt3/uWsjtxRkFk6s2yTHTefBLWoR+mKxDjO7QfzhycF1v8FXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/stellar-base": "^12.1.0",
-        "axios": "^1.7.2",
-        "bignumber.js": "^9.1.2",
-        "eventsource": "^2.0.2",
-        "randombytes": "^2.1.0",
-        "toml": "^3.0.0",
-        "urijs": "^1.19.1"
-      }
-    },
-    "node_modules/@stellar/freighter-api": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-1.7.1.tgz",
-      "integrity": "sha512-XvPO+XgEbkeP0VhP0U1edOkds+rGS28+y8GRGbCVXeZ9ZslbWqRFQoETAdX8IXGuykk2ib/aPokiLc5ZaWYP7w==",
-      "license": "Apache-2.0"
     },
     "node_modules/@stellar/js-xdr": {
       "version": "3.1.2",
@@ -2747,15 +2530,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3141,18 +2915,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "license": "Unlicense"
-    },
-    "node_modules/tweetnacl-util": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
-      "license": "Unlicense"
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@soroban-react/core": "^9.3.0",
     "@stellar/stellar-sdk": "^14.5.0",
     "@tanstack/react-query": "^5.90.21",
     "axios": "^1.13.5",


### PR DESCRIPTION
Closes #48 

**`package.json`** — removed `"@soroban-react/core": "^9.3.0"` from dependencies.

**`package-lock.json`** — removed 19 entries:
- All 5 `@soroban-react/*` packages and their nested `@stellar/stellar-sdk`/`@stellar/stellar-base` v12 overrides
- 3 packages that were exclusively soroban-react transitive deps: `@creit.tech/xbull-wallet-connect`, `@lobstrco/signer-extension-api`, `@stellar/freighter-api`
- 3 indirect transitive deps only pulled in through those: `rxjs`, `tweetnacl`, `tweetnacl-util`