### PR TITLE
fix: standardize UI theme — resolve green vs blue color inconsistency

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -132,7 +132,7 @@ function MockDashboard() {
             ].map(s => (
               <div key={s.label} className="rounded-lg p-2"
                    style={{ background: 'var(--bg-raised)', border: '1px solid rgba(255,255,255,0.06)' }}>
-                <p className="text-[11px] font-bold text-white">{s.val}</p>
+                <p className="text-[11px] font-bold text-text-1">{s.val}</p>
                 <p className="text-[9px]" style={{ color: 'var(--text-3)' }}>{s.label}</p>
                 <div className="mt-1 flex gap-0.5">
                   {[...Array(5)].map((_, i) => (
@@ -152,7 +152,7 @@ function MockDashboard() {
                style={{ border: '1px solid rgba(255,255,255,0.06)' }}>
             <div className="px-3 py-2 flex items-center justify-between"
                  style={{ background: 'var(--bg-raised)', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
-              <span className="text-[10px] font-semibold text-white">Recent Records</span>
+              <span className="text-[10px] font-semibold text-text-1">Recent Records</span>
               <div className="badge-green text-[9px] px-1.5 py-0.5">4 verified</div>
             </div>
             {[
@@ -163,7 +163,7 @@ function MockDashboard() {
               <div key={i} className="px-3 py-2 flex items-center justify-between"
                    style={{ background: i % 2 === 0 ? 'transparent' : 'rgba(255,255,255,0.01)', borderBottom: i < 2 ? '1px solid rgba(255,255,255,0.04)' : 'none' }}>
                 <div>
-                  <p className="text-[10px] font-medium text-white">{r.type}</p>
+                  <p className="text-[10px] font-medium text-text-1">{r.type}</p>
                   <p className="text-[9px]" style={{ color: 'var(--text-3)' }}>{r.doc}</p>
                 </div>
                 <div className="flex items-center gap-1">

--- a/src/app/appointments/page.tsx
+++ b/src/app/appointments/page.tsx
@@ -85,9 +85,9 @@ function BookingFlow() {
   return (
     <div className="space-y-6">
       {/* Step indicator */}
-      <div className="flex items-center gap-2 text-xs text-slate-400">
+      <div className="flex items-center gap-2 text-xs text-[--text-3]">
         {(['search', 'slots', 'form'] as Step[]).map((s, i) => (
-          <span key={s} className={`flex items-center gap-1 ${step === s ? 'text-blue-600 font-medium' : ''}`}>
+          <span key={s} className={`flex items-center gap-1 ${step === s ? 'text-[--green] font-medium' : ''}`}>
             {i > 0 && <span>›</span>}
             {s === 'search' ? 'Find Doctor' : s === 'slots' ? 'Pick Slot' : 'Book & Pay'}
           </span>
@@ -100,13 +100,13 @@ function BookingFlow() {
 
       {step === 'slots' && doctor && (
         <div>
-          <button onClick={() => setStep('search')} className="text-xs text-slate-400 hover:text-slate-600 mb-3">← Back</button>
-          <p className="font-semibold text-slate-900 mb-4">Dr. {doctor.name} — {doctor.specialty}</p>
+          <button onClick={() => setStep('search')} className="text-xs text-[--text-3] hover:text-[--text-1] mb-3">← Back</button>
+          <p className="font-semibold text-[--text-1] mb-4">Dr. {doctor.name} — {doctor.specialty}</p>
           <SlotPicker doctorId={doctor.id} selected={slot} onSelect={setSlot} />
           {slot && (
             <button
               onClick={() => setStep('form')}
-              className="mt-4 w-full rounded-md bg-blue-600 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+              className="mt-4 w-full rounded-md bg-[--green] py-2 text-sm font-semibold text-[#030D09] hover:bg-[#00DCA6]"
             >
               Continue
             </button>
@@ -116,10 +116,10 @@ function BookingFlow() {
 
       {step === 'form' && doctor && slot && (
         <div>
-          <button onClick={() => setStep('slots')} className="text-xs text-slate-400 hover:text-slate-600 mb-3">← Back</button>
+          <button onClick={() => setStep('slots')} className="text-xs text-[--text-3] hover:text-[--text-1] mb-3">← Back</button>
           <div className="space-y-4">
             <div>
-              <label className="block text-xs font-medium text-slate-600 mb-1">Appointment Type</label>
+              <label className="block text-xs font-medium text-[--text-2] mb-1">Appointment Type</label>
               <div className="flex gap-3">
                 {(['in-person', 'telemedicine'] as const).map((t) => (
                   <label key={t} className="flex items-center gap-1.5 text-sm cursor-pointer">
@@ -137,17 +137,17 @@ function BookingFlow() {
             </div>
 
             <div>
-              <label className="block text-xs font-medium text-slate-600 mb-1">Notes (optional)</label>
+              <label className="block text-xs font-medium text-[--text-2] mb-1">Notes (optional)</label>
               <textarea
                 rows={2}
                 value={form.notes}
                 onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))}
-                className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full rounded-md border border-[--border] px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[--green]"
               />
             </div>
 
             <div>
-              <label className="block text-xs font-medium text-slate-600 mb-1">Payment Method</label>
+              <label className="block text-xs font-medium text-[--text-2] mb-1">Payment Method</label>
               <div className="flex gap-3">
                 {(['stellar', 'traditional'] as const).map((m) => (
                   <label key={m} className="flex items-center gap-1.5 text-sm cursor-pointer">
@@ -164,11 +164,11 @@ function BookingFlow() {
               </div>
             </div>
 
-            <div className="rounded-lg bg-slate-50 p-3 text-sm">
-              <p className="text-slate-600">
+            <div className="rounded-lg bg-[--bg-inset] p-3 text-sm">
+              <p className="text-[--text-2]">
                 <span className="font-medium">Dr. {doctor.name}</span> · {new Date(slot.datetime).toLocaleString()}
               </p>
-              <p className="text-slate-500 text-xs mt-0.5">Fee: {FEE} XLM</p>
+              <p className="text-[--text-2] text-xs mt-0.5">Fee: {FEE} XLM</p>
             </div>
 
             {bookMutation.isError && (
@@ -178,7 +178,7 @@ function BookingFlow() {
             <button
               onClick={() => bookMutation.mutate()}
               disabled={bookMutation.isPending}
-              className="w-full rounded-md bg-blue-600 py-2 text-sm font-semibold text-white hover:bg-blue-500 disabled:opacity-50"
+              className="w-full rounded-md bg-[--green] py-2 text-sm font-semibold text-[#030D09] hover:bg-[#00DCA6] disabled:opacity-50"
             >
               {bookMutation.isPending ? 'Processing…' : 'Confirm & Pay'}
             </button>
@@ -194,11 +194,11 @@ export default function AppointmentsPage() {
     <ProtectedRoute requiredRole="PATIENT">
       <div className="mx-auto max-w-3xl px-4 py-8 space-y-10">
         <div>
-          <h1 className="text-2xl font-bold text-slate-900 mb-6">Book an Appointment</h1>
+          <h1 className="text-2xl font-bold text-[--text-1] mb-6">Book an Appointment</h1>
           <BookingFlow />
         </div>
         <div>
-          <h2 className="text-lg font-semibold text-slate-900 mb-4">Upcoming Appointments</h2>
+          <h2 className="text-lg font-semibold text-[--text-1] mb-4">Upcoming Appointments</h2>
           <UpcomingAppointments />
         </div>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,7 @@
 
 /* ─── Design tokens ─────────────────────────────────────────────── */
 :root {
+  --primary:      #00C896;
   --green:        #00C896;
   --green-dim:    #00A07A;
   --green-glow:   rgba(0, 200, 150, 0.18);

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -224,7 +224,7 @@ export default function LoginPage() {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center justify-between mb-1">
                       <span className="text-sm font-semibold text-text-1">{role.label}</span>
-                      <ChevronRight className="w-4 h-4 text-text-3 group-hover:text-green-500 transition-colors" />
+                      <ChevronRight className="w-4 h-4 text-text-3 group-hover:text-[--green] transition-colors" />
                     </div>
                     <p className="text-xs text-text-2 mb-2.5 leading-relaxed">{role.description}</p>
                     <div className="flex flex-wrap gap-1.5">
@@ -287,7 +287,7 @@ export default function LoginPage() {
                     <div className="flex items-center gap-3.5">
                       <div className="w-10 h-10 rounded-[10px] flex items-center justify-center shrink-0"
                            style={{ background: 'var(--bg-inset)', border: '1px solid rgba(255,255,255,0.08)' }}>
-                        <Wallet className="w-4.5 h-4.5 text-text-2 group-hover:text-green-500 transition-colors" style={{ width: '18px', height: '18px' }} />
+                        <Wallet className="w-4.5 h-4.5 text-text-2 group-hover:text-[--green] transition-colors" style={{ width: '18px', height: '18px' }} />
                       </div>
                       <div>
                         <p className="text-sm font-semibold text-text-1">{wallet.label}</p>
@@ -296,7 +296,7 @@ export default function LoginPage() {
                     </div>
                     {connecting === wallet.id
                       ? <Loader2 className="w-4 h-4 animate-spin" style={{ color: '#00C896' }} />
-                      : <ChevronRight className="w-4 h-4 text-text-3 group-hover:text-green-500 transition-colors" />
+                      : <ChevronRight className="w-4 h-4 text-text-3 group-hover:text-[--green] transition-colors" />
                     }
                   </button>
                 ))}

--- a/src/app/role-not-registered/page.tsx
+++ b/src/app/role-not-registered/page.tsx
@@ -25,8 +25,8 @@ export default function RoleNotRegisteredPage() {
         </svg>
       </div>
 
-      <h1 className="text-3xl font-bold text-slate-900">Role Not Registered</h1>
-      <p className="mt-4 text-base text-slate-600 max-w-md">
+      <h1 className="text-3xl font-bold text-[--text-1]">Role Not Registered</h1>
+      <p className="mt-4 text-base text-[--text-2] max-w-md">
         Your wallet is connected, but no role has been assigned to it on the
         Healthy-Stellar platform. Please contact the platform administrator to
         have your role assigned.
@@ -36,13 +36,13 @@ export default function RoleNotRegisteredPage() {
         <Link
           href="/"
           onClick={clearAuth}
-          className="rounded-md bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+          className="rounded-md bg-[--green] px-4 py-2.5 text-sm font-semibold text-[#030D09] shadow-sm hover:bg-[#00DCA6] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[--green]"
         >
           Disconnect &amp; Go Home
         </Link>
         <a
           href="mailto:support@healthy-stellar.io"
-          className="text-sm font-semibold text-slate-700 hover:text-slate-900"
+          className="text-sm font-semibold text-[--text-2] hover:text-[--text-1]"
         >
           Contact Support
         </a>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -28,13 +28,13 @@ export class ErrorBoundary extends Component<Props, State> {
       return (
         <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
           <p className="text-5xl">⚠️</p>
-          <h1 className="text-xl font-semibold text-slate-900">Something went wrong</h1>
-          <p className="text-sm text-slate-500 max-w-md">
+          <h1 className="text-xl font-semibold text-[--text-1]">Something went wrong</h1>
+          <p className="text-sm text-[--text-2] max-w-md">
             An unexpected error occurred. Please refresh the page or contact support if the problem persists.
           </p>
           <button
             onClick={() => this.setState({ hasError: false, error: null })}
-            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500"
+            className="rounded-md bg-[--green] px-4 py-2 text-sm font-medium text-[#030D09] hover:bg-[#00DCA6]"
           >
             Try again
           </button>

--- a/src/components/appointments/BookingConfirmation.tsx
+++ b/src/components/appointments/BookingConfirmation.tsx
@@ -39,25 +39,25 @@ export default function BookingConfirmation({ appointment, onDone }: Props) {
   return (
     <div className="flex flex-col items-center text-center py-12 px-4">
       <div className="text-5xl mb-4">✅</div>
-      <h2 className="text-xl font-bold text-slate-900 mb-2">Booking Confirmed!</h2>
-      <p className="text-sm text-slate-500 mb-1">
+      <h2 className="text-xl font-bold text-[--text-1] mb-2">Booking Confirmed!</h2>
+      <p className="text-sm text-[--text-2] mb-1">
         Appointment with <span className="font-medium">Dr. {appointment.doctorName}</span>
       </p>
-      <p className="text-sm text-slate-500 mb-1">
+      <p className="text-sm text-[--text-2] mb-1">
         {new Date(appointment.datetime).toLocaleString()} · {appointment.type}
       </p>
-      <p className="text-xs text-slate-400 mb-6">Ref: {appointment.id}</p>
+      <p className="text-xs text-[--text-3] mb-6">Ref: {appointment.id}</p>
 
       <div className="flex gap-3">
         <button
           onClick={downloadICS}
-          className="rounded-md border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          className="rounded-md border border-[--border] px-4 py-2 text-sm font-medium text-[--text-2] hover:bg-[--bg-hover]"
         >
           📅 Add to Calendar
         </button>
         <button
           onClick={onDone}
-          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+          className="rounded-md bg-[--green] px-4 py-2 text-sm font-semibold text-[#030D09] hover:bg-[#00DCA6]"
         >
           Done
         </button>

--- a/src/components/appointments/DoctorSearch.tsx
+++ b/src/components/appointments/DoctorSearch.tsx
@@ -69,8 +69,8 @@ export default function DoctorSearch({ onSelect }: Props) {
             onClick={() => handleSpecialtyChange(s === 'All' ? '' : s)}
             className={`rounded-full px-3 py-1 text-xs font-medium border transition-colors ${
               (s === 'All' && !specialty) || specialty === s
-                ? 'bg-blue-600 text-white border-blue-600'
-                : 'border-slate-200 text-slate-600 hover:bg-slate-50'
+                ? 'bg-[--green] text-[#030D09] border-[--green]'
+                : 'border-[--border] text-[--text-2] hover:bg-[--bg-hover]'
             }`}
           >
             {s}
@@ -80,7 +80,7 @@ export default function DoctorSearch({ onSelect }: Props) {
 
       {loading && (
         <div className="grid gap-3 sm:grid-cols-2">
-          <div className="col-span-full flex items-center justify-center py-8 gap-2 text-sm text-slate-400">
+          <div className="col-span-full flex items-center justify-center py-8 gap-2 text-sm text-[--text-3]">
             <Loader2 className="w-4 h-4 animate-spin" />
             Searching doctors…
           </div>
@@ -88,7 +88,7 @@ export default function DoctorSearch({ onSelect }: Props) {
       )}
 
       {!loading && doctors?.length === 0 && (
-        <p className="text-sm text-slate-400 text-center py-8">No doctors found for this specialty.</p>
+        <p className="text-sm text-[--text-3] text-center py-8">No doctors found for this specialty.</p>
       )}
 
       {!loading && doctors && doctors.length > 0 && (
@@ -97,10 +97,10 @@ export default function DoctorSearch({ onSelect }: Props) {
             <button
               key={doc.id}
               onClick={() => onSelect(doc)}
-              className="text-left rounded-xl border border-slate-200 bg-white p-4 hover:border-blue-400 hover:shadow-sm transition-all"
+              className="text-left rounded-xl border border-[--border] bg-[--bg-card] p-4 hover:border-[--green] hover:shadow-sm transition-all"
             >
-              <p className="font-semibold text-slate-900">{doc.name}</p>
-              <p className="text-xs text-slate-500">{doc.specialty}</p>
+              <p className="font-semibold text-[--text-1]">{doc.name}</p>
+              <p className="text-xs text-[--text-2]">{doc.specialty}</p>
             </button>
           ))}
         </div>

--- a/src/components/appointments/SlotPicker.tsx
+++ b/src/components/appointments/SlotPicker.tsx
@@ -24,18 +24,18 @@ export default function SlotPicker({ doctorId, selected, onSelect }: Props) {
     queryFn: () => fetchSlots(doctorId),
   });
 
-  if (isLoading) return <div className="animate-pulse h-32 rounded-xl bg-slate-200" />;
+  if (isLoading) return <div className="animate-pulse h-32 rounded-xl bg-[--bg-inset]" />;
 
   const grouped = groupByDate(slots?.filter((s) => s.available) ?? []);
   const dates = Object.keys(grouped);
 
-  if (dates.length === 0) return <p className="text-sm text-slate-400">No available slots.</p>;
+  if (dates.length === 0) return <p className="text-sm text-[--text-3]">No available slots.</p>;
 
   return (
     <div className="space-y-4">
       {dates.map((date) => (
         <div key={date}>
-          <p className="text-xs font-medium text-slate-500 mb-2">{date}</p>
+          <p className="text-xs font-medium text-[--text-2] mb-2">{date}</p>
           <div className="flex flex-wrap gap-2">
             {grouped[date].map((slot) => (
               <button
@@ -43,8 +43,8 @@ export default function SlotPicker({ doctorId, selected, onSelect }: Props) {
                 onClick={() => onSelect(slot)}
                 className={`rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${
                   selected?.id === slot.id
-                    ? 'bg-blue-600 text-white border-blue-600'
-                    : 'border-slate-200 text-slate-700 hover:bg-slate-50'
+                    ? 'bg-[--green] text-[#030D09] border-[--green]'
+                    : 'border-[--border] text-[--text-2] hover:bg-[--bg-hover]'
                 }`}
               >
                 {new Date(slot.datetime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}

--- a/src/components/appointments/UpcomingAppointments.tsx
+++ b/src/components/appointments/UpcomingAppointments.tsx
@@ -21,23 +21,23 @@ export default function UpcomingAppointments() {
 
   const upcoming = appointments?.filter((a) => a.status !== 'cancelled' && a.status !== 'completed') ?? [];
 
-  if (isLoading) return <div className="animate-pulse h-24 rounded-xl bg-slate-200" />;
+  if (isLoading) return <div className="animate-pulse h-24 rounded-xl bg-[--bg-inset]" />;
 
   if (upcoming.length === 0) return (
-    <p className="text-sm text-slate-400 text-center py-4">No upcoming appointments.</p>
+    <p className="text-sm text-[--text-3] text-center py-4">No upcoming appointments.</p>
   );
 
   return (
     <div className="space-y-3">
       {upcoming.map((appt) => (
-        <div key={appt.id} className="flex items-center justify-between rounded-xl border border-slate-200 bg-white p-4">
+        <div key={appt.id} className="flex items-center justify-between rounded-xl border border-[--border] bg-[--bg-card] p-4">
           <div>
-            <p className="font-medium text-slate-900">Dr. {appt.doctorName}</p>
-            <p className="text-xs text-slate-500">
+            <p className="font-medium text-[--text-1]">Dr. {appt.doctorName}</p>
+            <p className="text-xs text-[--text-2]">
               {new Date(appt.datetime).toLocaleString()} · {appt.type}
             </p>
             <span className={`mt-1 inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
-              appt.status === 'confirmed' ? 'bg-blue-100 text-blue-700' : 'bg-yellow-100 text-yellow-700'
+              appt.status === 'confirmed' ? 'bg-[--green-subtle] text-[--green]' : 'bg-yellow-100 text-yellow-700'
             }`}>
               {appt.status}
             </span>

--- a/src/components/doctor/AppointmentCard.tsx
+++ b/src/components/doctor/AppointmentCard.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 const STATUS_COLORS: Record<Appointment['status'], string> = {
   pending: 'bg-yellow-100 text-yellow-700',
-  confirmed: 'bg-blue-100 text-blue-700',
+  confirmed: 'bg-[--green-subtle] text-[--green]',
   completed: 'bg-green-100 text-green-700',
   cancelled: 'bg-red-100 text-red-700',
 };
@@ -38,14 +38,14 @@ export default function AppointmentCard({ appointment }: Props) {
   });
 
   return (
-    <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
+    <div className="rounded-xl border border-[--border] bg-[--bg-card] shadow-sm">
       <div
         className="flex items-center justify-between p-4 cursor-pointer"
         onClick={() => setExpanded((v) => !v)}
       >
         <div>
-          <p className="font-semibold text-slate-900">{appointment.patientName ?? appointment.patientAddress.slice(0, 8) + '…'}</p>
-          <p className="text-xs text-slate-500">
+          <p className="font-semibold text-[--text-1]">{appointment.patientName ?? appointment.patientAddress.slice(0, 8) + '…'}</p>
+          <p className="text-xs text-[--text-2]">
             {new Date(appointment.datetime).toLocaleString()} · {appointment.type}
           </p>
         </div>
@@ -55,7 +55,7 @@ export default function AppointmentCard({ appointment }: Props) {
       </div>
 
       {expanded && (
-        <div className="border-t border-slate-100 p-4 space-y-4">
+        <div className="border-t border-[--border] p-4 space-y-4">
           {/* Status actions */}
           {appointment.status !== 'completed' && appointment.status !== 'cancelled' && (
             <div className="flex gap-2">
@@ -63,7 +63,7 @@ export default function AppointmentCard({ appointment }: Props) {
                 <button
                   onClick={() => statusMutation.mutate('confirmed')}
                   disabled={statusMutation.isPending}
-                  className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-500 disabled:opacity-50"
+                  className="rounded-md bg-[--green] px-3 py-1.5 text-xs font-medium text-[#030D09] hover:bg-[#00DCA6] disabled:opacity-50"
                 >
                   Confirm
                 </button>
@@ -89,16 +89,16 @@ export default function AppointmentCard({ appointment }: Props) {
 
           {/* Patient medical history */}
           <div>
-            <p className="text-xs font-medium text-slate-500 mb-2">Patient History</p>
-            {!patientRecords && <p className="text-xs text-slate-400">Loading…</p>}
-            {patientRecords?.length === 0 && <p className="text-xs text-slate-400">No records found.</p>}
+            <p className="text-xs font-medium text-[--text-2] mb-2">Patient History</p>
+            {!patientRecords && <p className="text-xs text-[--text-3]">Loading…</p>}
+            {patientRecords?.length === 0 && <p className="text-xs text-[--text-3]">No records found.</p>}
             {patientRecords && patientRecords.length > 0 && (
               <ul className="space-y-1">
                 {patientRecords.map((r) => (
                   <li key={r.id}>
                     <button
                       onClick={() => setSelectedRecord(r)}
-                      className="text-xs text-blue-600 hover:underline"
+                      className="text-xs text-[--green] hover:underline"
                     >
                       {new Date(r.date).toLocaleDateString()} — {r.diagnosis}
                     </button>
@@ -112,7 +112,7 @@ export default function AppointmentCard({ appointment }: Props) {
           <div>
             <button
               onClick={() => setShowRecordForm((v) => !v)}
-              className="text-xs font-medium text-blue-600 hover:underline"
+              className="text-xs font-medium text-[--green] hover:underline"
             >
               {showRecordForm ? 'Hide form' : '+ Add Medical Record'}
             </button>

--- a/src/components/doctor/AppointmentCard.tsx
+++ b/src/components/doctor/AppointmentCard.tsx
@@ -16,7 +16,7 @@ interface Props {
 const STATUS_COLORS: Record<Appointment['status'], string> = {
   pending: 'bg-yellow-100 text-yellow-700',
   confirmed: 'bg-[--green-subtle] text-[--green]',
-  completed: 'bg-green-100 text-green-700',
+  completed: 'bg-[--green-subtle] text-[--green]',
   cancelled: 'bg-red-100 text-red-700',
 };
 
@@ -72,7 +72,7 @@ export default function AppointmentCard({ appointment }: Props) {
                 <button
                   onClick={() => statusMutation.mutate('completed')}
                   disabled={statusMutation.isPending}
-                  className="rounded-md bg-green-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-500 disabled:opacity-50"
+                  className="rounded-md bg-[--green] px-3 py-1.5 text-xs font-medium text-[#030D09] hover:bg-[#00DCA6] disabled:opacity-50"
                 >
                   Mark Complete
                 </button>

--- a/src/components/doctor/NewRecordForm.tsx
+++ b/src/components/doctor/NewRecordForm.tsx
@@ -66,29 +66,29 @@ export default function NewRecordForm({ patientAddress, onSuccess }: Props) {
       className="space-y-3"
     >
       <div>
-        <label className="block text-xs font-medium text-slate-600 mb-1">Diagnosis *</label>
+        <label className="block text-xs font-medium text-[--text-2] mb-1">Diagnosis *</label>
         <input
           required
           value={form.diagnosis}
           onChange={(e) => setForm((f) => ({ ...f, diagnosis: e.target.value }))}
-          className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="w-full rounded-md border border-[--border] px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[--green]"
         />
       </div>
       <div>
-        <label className="block text-xs font-medium text-slate-600 mb-1">Prescription</label>
+        <label className="block text-xs font-medium text-[--text-2] mb-1">Prescription</label>
         <input
           value={form.prescription}
           onChange={(e) => setForm((f) => ({ ...f, prescription: e.target.value }))}
-          className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="w-full rounded-md border border-[--border] px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[--green]"
         />
       </div>
       <div>
-        <label className="block text-xs font-medium text-slate-600 mb-1">Notes</label>
+        <label className="block text-xs font-medium text-[--text-2] mb-1">Notes</label>
         <textarea
           rows={3}
           value={form.notes}
           onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))}
-          className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="w-full rounded-md border border-[--border] px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[--green]"
         />
       </div>
 
@@ -99,7 +99,7 @@ export default function NewRecordForm({ patientAddress, onSuccess }: Props) {
       <button
         type="submit"
         disabled={mutation.isPending}
-        className="w-full rounded-md bg-blue-600 py-2 text-sm font-semibold text-white hover:bg-blue-500 disabled:opacity-50"
+        className="w-full rounded-md bg-[--green] py-2 text-sm font-semibold text-[#030D09] hover:bg-[#00DCA6] disabled:opacity-50"
       >
         {mutation.isPending ? 'Submitting…' : 'Submit Record'}
       </button>

--- a/src/components/navigation/Header.tsx
+++ b/src/components/navigation/Header.tsx
@@ -15,7 +15,7 @@ export function Header() {
     : null;
 
   return (
-    <header className="border-b border-slate-200 bg-white">
+    <header className="border-b border-[--border] bg-[--bg-raised]">
       <nav
         className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6 lg:px-8"
         aria-label="Global"
@@ -23,19 +23,19 @@ export function Header() {
         {/* Brand */}
         <Link
           href="/"
-          className="text-lg font-bold text-blue-600 hover:text-blue-500"
+          className="text-lg font-bold text-[--green] hover:text-[#00DCA6]"
         >
           Healthy-Stellar
         </Link>
 
         {/* Role-specific nav links */}
-        <div className="flex items-center gap-6 text-sm font-medium text-slate-700">
+        <div className="flex items-center gap-6 text-sm font-medium text-[--text-2]">
           {role === 'PATIENT' && (
             <>
-              <Link href="/dashboard/patient" className="hover:text-blue-600">
+              <Link href="/dashboard/patient" className="hover:text-[--green]">
                 My Records
               </Link>
-              <Link href="/dashboard/patient" className="hover:text-blue-600">
+              <Link href="/dashboard/patient" className="hover:text-[--green]">
                 Appointments
               </Link>
             </>
@@ -43,10 +43,10 @@ export function Header() {
 
           {role === 'DOCTOR' && (
             <>
-              <Link href="/dashboard/doctor" className="hover:text-blue-600">
+              <Link href="/dashboard/doctor" className="hover:text-[--green]">
                 Patients
               </Link>
-              <Link href="/dashboard/doctor" className="hover:text-blue-600">
+              <Link href="/dashboard/doctor" className="hover:text-[--green]">
                 Consultations
               </Link>
             </>
@@ -54,10 +54,10 @@ export function Header() {
 
           {role === 'HOSPITAL' && (
             <>
-              <Link href="/dashboard/hospital" className="hover:text-blue-600">
+              <Link href="/dashboard/hospital" className="hover:text-[--green]">
                 Staff
               </Link>
-              <Link href="/dashboard/hospital" className="hover:text-blue-600">
+              <Link href="/dashboard/hospital" className="hover:text-[--green]">
                 Departments
               </Link>
             </>
@@ -65,10 +65,10 @@ export function Header() {
 
           {role === 'ADMIN' && (
             <>
-              <Link href="/dashboard/admin" className="hover:text-blue-600">
+              <Link href="/dashboard/admin" className="hover:text-[--green]">
                 Users
               </Link>
-              <Link href="/dashboard/admin" className="hover:text-blue-600">
+              <Link href="/dashboard/admin" className="hover:text-[--green]">
                 Settings
               </Link>
             </>
@@ -78,7 +78,7 @@ export function Header() {
           {role && (
             <Link
               href={ROLE_DASHBOARD_MAP[role]}
-              className="rounded-md bg-blue-50 px-3 py-1.5 text-blue-700 hover:bg-blue-100"
+              className="rounded-md bg-[--green-subtle] px-3 py-1.5 text-[--green] hover:bg-[rgba(0,200,150,0.14)]"
             >
               Dashboard
             </Link>
@@ -88,7 +88,7 @@ export function Header() {
           {walletAddress ? (
             <button
               onClick={clearAuth}
-              className="text-slate-500 hover:text-red-600"
+              className="text-[--text-3] hover:text-red-600"
               title={walletAddress}
             >
               {shortAddress} · Disconnect
@@ -96,7 +96,7 @@ export function Header() {
           ) : (
             <Link
               href="/login"
-              className="rounded-md bg-blue-600 px-3.5 py-2 text-white hover:bg-blue-500"
+              className="rounded-md bg-[--green] px-3.5 py-2 text-[#030D09] hover:bg-[#00DCA6]"
             >
               Connect Wallet
             </Link>

--- a/src/components/records/MedicalRecordUpload.tsx
+++ b/src/components/records/MedicalRecordUpload.tsx
@@ -73,13 +73,13 @@ export default function MedicalRecordUpload({ patientAddress, onUploaded }: Prop
   const busy = mutation.isPending;
 
   return (
-    <div className="rounded-xl border-2 border-dashed border-slate-200 bg-white p-6 text-center">
+    <div className="rounded-xl border-2 border-dashed border-[--border] bg-[--bg-card] p-6 text-center">
       <p className="text-3xl mb-2">🔒</p>
-      <p className="font-medium text-slate-700">Upload Encrypted Medical Record</p>
-      <p className="text-xs text-slate-400 mt-1">PDF, JPEG or PNG · max 10 MB · encrypted before upload</p>
+      <p className="font-medium text-[--text-1]">Upload Encrypted Medical Record</p>
+      <p className="text-xs text-[--text-3] mt-1">PDF, JPEG or PNG · max 10 MB · encrypted before upload</p>
 
       {progress !== 'idle' && (
-        <p className="mt-3 text-sm text-blue-600 animate-pulse">
+        <p className="mt-3 text-sm text-[--green] animate-pulse">
           {progress === 'encrypting' ? 'Encrypting file…' : 'Uploading…'}
         </p>
       )}
@@ -87,7 +87,7 @@ export default function MedicalRecordUpload({ patientAddress, onUploaded }: Prop
       <button
         onClick={() => inputRef.current?.click()}
         disabled={busy}
-        className="mt-4 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-50"
+        className="mt-4 rounded-md bg-[--green] px-4 py-2 text-sm font-medium text-[#030D09] hover:bg-[#00DCA6] disabled:opacity-50"
       >
         {busy ? 'Processing…' : 'Choose File'}
       </button>

--- a/src/components/records/RecordCard.tsx
+++ b/src/components/records/RecordCard.tsx
@@ -32,13 +32,13 @@ export default function RecordCard({ record }: Props) {
 
   return (
     <>
-      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm hover:shadow-md transition-shadow">
-        <p className="text-xs text-slate-400">{new Date(record.date).toLocaleDateString()}</p>
-        <p className="mt-1 font-semibold text-slate-900">{record.diagnosis}</p>
-        <p className="text-sm text-slate-500">Dr. {record.doctorName}</p>
+      <div className="card">
+        <p className="text-xs text-[--text-3]">{new Date(record.date).toLocaleDateString()}</p>
+        <p className="mt-1 font-semibold text-[--text-1]">{record.diagnosis}</p>
+        <p className="text-sm text-[--text-2]">Dr. {record.doctorName}</p>
 
         {shareInfo && (
-          <div className="mt-2 rounded-md bg-green-50 p-2 text-xs text-green-700">
+          <div className="mt-2 rounded-md bg-[--green-subtle] p-2 text-xs text-[--green]">
             Token: <span className="font-mono break-all">{shareInfo.token}</span>
             <br />Expires: {new Date(shareInfo.expiresAt).toLocaleString()}
           </div>
@@ -47,14 +47,14 @@ export default function RecordCard({ record }: Props) {
         <div className="mt-3 flex gap-2">
           <button
             onClick={() => setShowDrawer(true)}
-            className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-500"
+            className="btn-primary !text-xs !px-3 !py-1.5"
           >
             View
           </button>
           <button
             onClick={handleShare}
             disabled={sharing}
-            className="rounded-md border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+            className="rounded-md border border-[--border] px-3 py-1.5 text-xs font-medium text-[--text-2] hover:bg-[--bg-hover] disabled:opacity-50"
           >
             {sharing ? 'Sharing…' : 'Share'}
           </button>

--- a/src/components/records/RecordDetailDrawer.tsx
+++ b/src/components/records/RecordDetailDrawer.tsx
@@ -11,37 +11,37 @@ export default function RecordDetailDrawer({ record, onClose }: Props) {
   return (
     <div className="fixed inset-0 z-50 flex justify-end bg-black/40" onClick={onClose} role="dialog" aria-modal="true" aria-labelledby="record-detail-title">
       <div
-        className="h-full w-full max-w-md bg-white shadow-xl overflow-y-auto p-6"
+        className="h-full w-full max-w-md bg-[--bg-card] shadow-xl overflow-y-auto p-6"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex justify-between items-center mb-6">
-          <h2 id="record-detail-title" className="text-lg font-semibold text-slate-900">Record Details</h2>
-          <button onClick={onClose} aria-label="Close record details" className="text-slate-400 hover:text-slate-600 text-2xl leading-none">&times;</button>
+          <h2 id="record-detail-title" className="text-lg font-semibold text-[--text-1]">Record Details</h2>
+          <button onClick={onClose} aria-label="Close record details" className="text-[--text-3] hover:text-[--text-1] text-2xl leading-none">&times;</button>
         </div>
 
         <dl className="space-y-4 text-sm">
           <div>
-            <dt className="font-medium text-slate-500">Date</dt>
-            <dd className="mt-1 text-slate-900">{new Date(record.date).toLocaleDateString()}</dd>
+            <dt className="font-medium text-[--text-2]">Date</dt>
+            <dd className="mt-1 text-[--text-1]">{new Date(record.date).toLocaleDateString()}</dd>
           </div>
           <div>
-            <dt className="font-medium text-slate-500">Doctor</dt>
-            <dd className="mt-1 text-slate-900">{record.doctorName}</dd>
+            <dt className="font-medium text-[--text-2]">Doctor</dt>
+            <dd className="mt-1 text-[--text-1]">{record.doctorName}</dd>
           </div>
           <div>
-            <dt className="font-medium text-slate-500">Diagnosis</dt>
-            <dd className="mt-1 text-slate-900">{record.diagnosis}</dd>
+            <dt className="font-medium text-[--text-2]">Diagnosis</dt>
+            <dd className="mt-1 text-[--text-1]">{record.diagnosis}</dd>
           </div>
           {record.prescription && (
             <div>
-              <dt className="font-medium text-slate-500">Prescription</dt>
-              <dd className="mt-1 text-slate-900">{record.prescription}</dd>
+              <dt className="font-medium text-[--text-2]">Prescription</dt>
+              <dd className="mt-1 text-[--text-1]">{record.prescription}</dd>
             </div>
           )}
           {record.notes && (
             <div>
-              <dt className="font-medium text-slate-500">Notes</dt>
-              <dd className="mt-1 text-slate-900 whitespace-pre-wrap">{record.notes}</dd>
+              <dt className="font-medium text-[--text-2]">Notes</dt>
+              <dd className="mt-1 text-[--text-1] whitespace-pre-wrap">{record.notes}</dd>
             </div>
           )}
         </dl>

--- a/src/components/records/RecordSkeleton.tsx
+++ b/src/components/records/RecordSkeleton.tsx
@@ -2,11 +2,11 @@
 
 export function RecordSkeleton() {
   return (
-    <div className="animate-pulse rounded-xl border border-slate-200 bg-white p-4 space-y-3">
-      <div className="h-3 w-1/3 rounded bg-slate-200" />
-      <div className="h-4 w-2/3 rounded bg-slate-200" />
-      <div className="h-3 w-1/2 rounded bg-slate-200" />
-      <div className="h-8 w-20 rounded bg-slate-200 mt-2" />
+    <div className="animate-pulse rounded-xl border border-[--border] bg-[--bg-card] p-4 space-y-3">
+      <div className="h-3 w-1/3 rounded bg-[--bg-inset]" />
+      <div className="h-4 w-2/3 rounded bg-[--bg-inset]" />
+      <div className="h-3 w-1/2 rounded bg-[--bg-inset]" />
+      <div className="h-8 w-20 rounded bg-[--bg-inset] mt-2" />
     </div>
   );
 }

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -24,7 +24,7 @@ const ICONS: Record<ToastType, string> = {
 };
 
 const STYLES: Record<ToastType, string> = {
-  success: 'bg-green-600',
+  success: 'bg-[--green]',
   error: 'bg-red-600',
   warning: 'bg-yellow-500',
   info: 'bg-[--green]',

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -27,7 +27,7 @@ const STYLES: Record<ToastType, string> = {
   success: 'bg-green-600',
   error: 'bg-red-600',
   warning: 'bg-yellow-500',
-  info: 'bg-blue-600',
+  info: 'bg-[--green]',
 };
 
 export function ToastProvider({ children }: { children: ReactNode }) {

--- a/src/components/wallet/ConnectWalletModal.tsx
+++ b/src/components/wallet/ConnectWalletModal.tsx
@@ -115,10 +115,10 @@ export default function ConnectWalletModal({ onClose }: Props) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-modal="true" aria-labelledby="connect-wallet-title" onKeyDown={handleKeyDown}>
-      <div ref={modalRef} className="bg-white rounded-xl shadow-xl w-full max-w-sm p-6">
+      <div ref={modalRef} className="bg-[--bg-card] rounded-xl shadow-xl w-full max-w-sm p-6">
         <div className="flex justify-between items-center mb-4">
-          <h2 id="connect-wallet-title" className="text-lg font-semibold text-slate-900">Connect Wallet</h2>
-          <button onClick={onClose} aria-label="Close dialog" className="text-slate-400 hover:text-slate-600 text-xl leading-none">&times;</button>
+          <h2 id="connect-wallet-title" className="text-lg font-semibold text-[--text-1]">Connect Wallet</h2>
+          <button onClick={onClose} aria-label="Close dialog" className="text-[--text-3] hover:text-[--text-1] text-xl leading-none">&times;</button>
         </div>
 
         {error && (
@@ -129,20 +129,20 @@ export default function ConnectWalletModal({ onClose }: Props) {
           <button
             onClick={connectFreighter}
             disabled={!!loading}
-            className="flex items-center justify-center gap-2 w-full rounded-lg border border-slate-200 px-4 py-3 text-sm font-medium hover:bg-slate-50 disabled:opacity-50"
+            className="flex items-center justify-center gap-2 w-full rounded-lg border border-[--border] px-4 py-3 text-sm font-medium hover:bg-[--bg-hover] disabled:opacity-50"
           >
             {loading === 'freighter' ? 'Connecting…' : '🔑 Freighter'}
           </button>
           <button
             onClick={connectAlbedo}
             disabled={!!loading}
-            className="flex items-center justify-center gap-2 w-full rounded-lg border border-slate-200 px-4 py-3 text-sm font-medium hover:bg-slate-50 disabled:opacity-50"
+            className="flex items-center justify-center gap-2 w-full rounded-lg border border-[--border] px-4 py-3 text-sm font-medium hover:bg-[--bg-hover] disabled:opacity-50"
           >
             {loading === 'albedo' ? 'Connecting…' : '🌐 Albedo'}
           </button>
         </div>
 
-        <p className="mt-4 text-xs text-slate-400 text-center">Network: {network}</p>
+        <p className="mt-4 text-xs text-[--text-3] text-center">Network: {network}</p>
       </div>
     </div>
   );

--- a/src/components/wallet/Navbar.tsx
+++ b/src/components/wallet/Navbar.tsx
@@ -17,17 +17,17 @@ export default function Navbar() {
 
   return (
     <>
-      <nav className="sticky top-0 z-40 w-full border-b border-slate-200 bg-white/80 backdrop-blur">
+      <nav className="sticky top-0 z-40 w-full border-b border-[--border] bg-[--bg-raised]/80 backdrop-blur">
         <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
-          <Link href="/" className="font-bold text-blue-600 text-lg">HealthyStella</Link>
+          <Link href="/" className="font-bold text-[--green] text-lg">HealthyStella</Link>
 
           <div className="flex items-center gap-3">
             {publicKey ? (
               <>
-                <Link href={dashboardHref} className="text-sm text-slate-600 hover:text-slate-900">
+                <Link href={dashboardHref} className="text-sm text-[--text-2] hover:text-[--text-1]">
                   Dashboard
                 </Link>
-                <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-mono text-slate-700">
+                <span className="rounded-full bg-[--bg-hover] px-3 py-1 text-xs font-mono text-[--text-2]">
                   {truncate(publicKey)}
                 </span>
                 <button
@@ -40,7 +40,7 @@ export default function Navbar() {
             ) : (
               <button
                 onClick={() => setShowModal(true)}
-                className="rounded-md bg-blue-600 px-3.5 py-1.5 text-sm font-semibold text-white hover:bg-blue-500"
+                className="rounded-md bg-[--green] px-3.5 py-1.5 text-sm font-semibold text-[#030D09] hover:bg-[#00DCA6]"
               >
                 Connect Wallet
               </button>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,7 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
+        primary: 'var(--primary)',
         green: {
           DEFAULT: '#00C896',
           50:  '#E6FFF8',
@@ -23,21 +24,21 @@ const config: Config = {
           900: '#002818',
         },
         surface: {
-          base:   '#0B0E0D',
-          raised: '#111614',
-          card:   '#161B19',
-          inset:  '#1A201E',
-          hover:  '#1F2724',
+          base:   'var(--bg-base)',
+          raised: 'var(--bg-raised)',
+          card:   'var(--bg-card)',
+          inset:  'var(--bg-inset)',
+          hover:  'var(--bg-hover)',
         },
         border: {
-          DEFAULT: 'rgba(255,255,255,0.07)',
-          focus:   'rgba(0,200,150,0.35)',
+          DEFAULT: 'var(--border)',
+          focus:   'var(--border-focus)',
           strong:  'rgba(255,255,255,0.12)',
         },
         text: {
-          1: '#F0F5F3',
-          2: '#8E9E99',
-          3: '#4E5E5A',
+          1: 'var(--text-1)',
+          2: 'var(--text-2)',
+          3: 'var(--text-3)',
         },
       },
       fontFamily: {


### PR DESCRIPTION
Closes #49

## Summary

Audited all components for hardcoded blue/white/slate Tailwind classes that conflicted with the dark green theme and migrated them to use CSS variable tokens.

### Changes
- Added `--primary` CSS variable as alias for `--green`
- Updated `tailwind.config.ts` to map surface, border, and text colors to CSS variables
- Migrated all identified components to use CSS variable tokens instead of hardcoded colors

### Testing
- Verified all blue/slate/white classes replaced with green theme tokens
- TypeScript compiles without new errors
- All components use consistent CSS variable references