### PR TITLE
Fix README git clone URL typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To get a local copy up and running, follow these steps:
 
 Clone the repository:
 
-git clone https://github.com/your-username/Healthy-Stellar-frontend.gitt
+git clone https://github.com/your-username/Healthy-Stellar-frontend.git
 
 Navigate to the project directory:
 


### PR DESCRIPTION
Closes #52

Summary:
Fixes a typo in the README git clone command.

Changes:

- Updated clone URL extension:
  - .gitt → .git

Impact:

- New contributors can copy and run the clone command successfully.
- No code or configuration changes included.

Validation:

- Confirmed README clone command now uses the correct git URL format.