### PR TITLE
Fix/audit issues

### DIFF
--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -268,6 +268,7 @@ function AdminDashboardContent() {
                     value={search}
                     onChange={e => setSearch(e.target.value)}
                     placeholder="Search users..."
+                    aria-label="Search users"
                     className="w-full pl-8 pr-3 py-2 text-xs rounded-[9px] outline-none"
                     style={{
                       background: 'var(--bg-inset)',

--- a/src/app/dashboard/hospital/page.tsx
+++ b/src/app/dashboard/hospital/page.tsx
@@ -312,6 +312,7 @@ function HospitalDashboardContent() {
               <Search className="w-3.5 h-3.5 text-text-3 absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none" />
               <input
                 placeholder="Search by name or department…"
+                aria-label="Search by name or department"
                 className="input text-xs py-1.5 pl-8 w-52"
                 value={staffSearch}
                 onChange={e => setStaffSearch(e.target.value)}

--- a/src/components/appointments/DoctorSearch.tsx
+++ b/src/components/appointments/DoctorSearch.tsx
@@ -1,10 +1,22 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, memo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchDoctors } from '@/services/api.service';
 import { Doctor } from '@/types';
 import { Loader2 } from 'lucide-react';
+
+const DoctorResultCard = memo(function DoctorResultCard({ doc, onSelect }: { doc: Doctor; onSelect: (doctor: Doctor) => void }) {
+  return (
+    <button
+      onClick={() => onSelect(doc)}
+      className="text-left rounded-xl border border-border bg-surface-card p-4 hover:border-green hover:shadow-card transition-all"
+    >
+      <p className="font-semibold text-text-1">{doc.name}</p>
+      <p className="text-xs text-text-2">{doc.specialty}</p>
+    </button>
+  );
+});
 
 const SPECIALTIES = ['All', 'General', 'Cardiology', 'Dermatology', 'Neurology', 'Pediatrics'];
 const DEBOUNCE_MS = 300;
@@ -93,14 +105,7 @@ export default function DoctorSearch({ onSelect }: Props) {
       {!loading && doctors && doctors.length > 0 && (
         <div className="grid gap-3 sm:grid-cols-2">
           {doctors.map((doc) => (
-            <button
-              key={doc.id}
-              onClick={() => onSelect(doc)}
-              className="text-left rounded-xl border border-border bg-surface-card p-4 hover:border-green hover:shadow-card transition-all"
-            >
-              <p className="font-semibold text-text-1">{doc.name}</p>
-              <p className="text-xs text-text-2">{doc.specialty}</p>
-            </button>
+            <DoctorResultCard key={doc.id} doc={doc} onSelect={onSelect} />
           ))}
         </div>
       )}

--- a/src/components/doctor/AppointmentCard.tsx
+++ b/src/components/doctor/AppointmentCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Appointment } from '@/types';
 import { updateAppointmentStatus } from '@/services/api.service';
@@ -21,7 +21,7 @@ const STATUS_COLORS: Record<Appointment['status'], string> = {
   cancelled: 'bg-red-100 text-red-700',
 };
 
-export default function AppointmentCard({ appointment: rawAppointment }: Props) {
+function AppointmentCard({ appointment: rawAppointment }: Props) {
   const appointment = withVideoRoom(rawAppointment);
   const queryClient = useQueryClient();
   const [expanded, setExpanded] = useState(false);
@@ -136,3 +136,5 @@ export default function AppointmentCard({ appointment: rawAppointment }: Props) 
     </div>
   );
 }
+
+export default memo(AppointmentCard);

--- a/src/components/records/RecordCard.tsx
+++ b/src/components/records/RecordCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { MedicalRecord } from '@/types';
 import { shareRecord } from '@/services/api.service';
 import RecordDetailDrawer from './RecordDetailDrawer';
@@ -10,7 +10,7 @@ interface Props {
   record: MedicalRecord;
 }
 
-export default function RecordCard({ record }: Props) {
+function RecordCard({ record }: Props) {
   const { toast } = useToast();
   const [showDrawer, setShowDrawer] = useState(false);
   const [sharing, setSharing] = useState(false);
@@ -65,3 +65,5 @@ export default function RecordCard({ record }: Props) {
     </>
   );
 }
+
+export default memo(RecordCard);

--- a/src/components/wallet/ConnectWalletModal.tsx
+++ b/src/components/wallet/ConnectWalletModal.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 type WalletOption = 'freighter' | 'albedo';
 
-function useFocusTrap(ref: React.RefObject<HTMLElement | null>) {
+function useFocusTrap(ref: React.RefObject<HTMLElement | null>, onClose: () => void) {
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
@@ -28,6 +28,7 @@ function useFocusTrap(ref: React.RefObject<HTMLElement | null>) {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === 'Escape') {
         e.preventDefault();
+        onClose();
         return;
       }
       if (e.key !== 'Tab') return;
@@ -53,7 +54,7 @@ function useFocusTrap(ref: React.RefObject<HTMLElement | null>) {
       el.removeEventListener('keydown', handleKeyDown);
       previouslyFocused?.focus();
     };
-  }, [ref]);
+  }, [ref, onClose]);
 }
 
 export default function ConnectWalletModal({ onClose }: Props) {
@@ -62,7 +63,7 @@ export default function ConnectWalletModal({ onClose }: Props) {
   const [loading, setLoading] = useState<WalletOption | null>(null);
   const modalRef = useRef<HTMLDivElement>(null);
 
-  useFocusTrap(modalRef);
+  useFocusTrap(modalRef, onClose);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Escape') onClose();

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -1,7 +1,59 @@
 import { Networks } from '@stellar/stellar-sdk';
+import { useCallback } from 'react';
+import { useToast } from '@/hooks/useToast';
 
 export const STELLAR_CONFIG = {
   network: process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet',
   horizonUrl: process.env.NEXT_PUBLIC_HORIZON_URL || 'https://horizon-testnet.stellar.org',
   passphrase: Networks.TESTNET,
 };
+
+export class HorizonRequestError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'HorizonRequestError';
+  }
+}
+
+/**
+ * Normalizes Horizon network errors, rate limits, and invalid responses into a
+ * single HorizonRequestError instead of letting them throw unhandled/crash the UI.
+ */
+export async function callHorizon<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err: unknown) {
+    if (err instanceof TypeError) {
+      throw new HorizonRequestError('Unable to reach the Stellar network. Check your connection and try again.', err);
+    }
+    const status = (err as { response?: { status?: number } })?.response?.status;
+    if (status === 429) {
+      throw new HorizonRequestError('Stellar network rate limit reached. Please try again shortly.', err);
+    }
+    if (status && status >= 500) {
+      throw new HorizonRequestError('Stellar Horizon service is temporarily unavailable.', err);
+    }
+    if (status && status >= 400) {
+      throw new HorizonRequestError('Invalid request sent to the Stellar network.', err);
+    }
+    throw new HorizonRequestError('Unexpected error communicating with the Stellar network.', err);
+  }
+}
+
+/** Runs a Horizon call and surfaces any failure via the toast system instead of failing silently. */
+export function useHorizonCall() {
+  const { toast } = useToast();
+
+  return useCallback(
+    async <T,>(fn: () => Promise<T>): Promise<T | undefined> => {
+      try {
+        return await callHorizon(fn);
+      } catch (err) {
+        const message = err instanceof HorizonRequestError ? err.message : 'Failed to communicate with the Stellar network.';
+        toast(message, 'error');
+        return undefined;
+      }
+    },
+    [toast]
+  );
+}


### PR DESCRIPTION
closes #101
closes #99 
closes #100
closes #102 
closes #103 

src/lib/stellar.ts talks to the configurable Horizon endpoint (NEXT_PUBLIC_HORIZON_URL) but it's unclear whether network errors, rate limits, or invalid responses from Horizon are caught and surfaced to the user rather than throwing unhandled exceptions.

Dashboard list views (records, appointments, doctors) re-render their full lists on every parent state change, since there's no memoization in place.
src/components/wallet's connect modal doesn't appear to trap focus or support Escape-to-close/Tab cycling, making it inaccessible to keyboard-only users.

