### PR TITLE
docs: add GitHub issue templates (bug report & feature request)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report a problem to help us improve
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+## Description
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Expected Behavior
+What you expected to happen.
+
+## Actual Behavior
+What actually happened.
+
+## Environment
+- OS:
+- Browser/Version:
+- Node version:
+- App version/commit:
+
+## Screenshots / Logs
+If applicable, add screenshots or console/network logs.
+
+## Additional Context
+Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contributing Guide
+    url: https://github.com/Healthy-Stellar/Healthy-Stellar-frontend/blob/main/CONTRIBUTING.md
+    about: Please read our contributing guidelines before opening an issue or PR.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: "[Feature]: "
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+What problem does this feature solve? Is it related to an existing pain point?
+
+## Proposed Solution
+Describe the solution you'd like.
+
+## Alternatives Considered
+Any alternative solutions or features you've considered.
+
+## Additional Context
+Any other context, mockups, or examples.


### PR DESCRIPTION
## Summary
Adds structured GitHub issue templates so new issues follow a consistent format instead of free-form text.

## Changes
- `.github/ISSUE_TEMPLATE/bug_report.md` — steps to reproduce, expected/actual behavior, environment
- `.github/ISSUE_TEMPLATE/feature_request.md` — problem statement, proposed solution, alternatives
- `.github/ISSUE_TEMPLATE/config.yml` — links contributors to CONTRIBUTING.md

## Context
The repo previously had no issue templates, so incoming issues had no consistent structure.

## Testing
Verified template front matter renders correctly in GitHub's "New issue" chooser (validated YAML front matter locally; docs-only change, no build/runtime impact).

Closes #75