### PR TITLE
docs: add JSDoc comments to src/services/api.service.ts

### DIFF
--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -2,6 +2,12 @@ import axios from 'axios';
 import axiosRetry from 'axios-retry';
 import type { MedicalRecord, ShareToken, Doctor, TimeSlot, Appointment, NewRecordPayload, EncryptedRecord, StaffMember, PatientAdmission, HospitalMetrics, ComplianceReport, BulkRecordImportRow, BulkImportResponse } from '@/types';
 
+/**
+ * Shared axios instance for all API calls.
+ * - `baseURL`: read from `NEXT_PUBLIC_API_URL` (empty string if unset, i.e. relative requests).
+ * - `headers`: defaults to `Content-Type: application/json`; overridden per-call where needed
+ *   (e.g. multipart uploads in {@link uploadEncryptedRecord}).
+ */
 const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL ?? '',
   headers: { 'Content-Type': 'application/json' },
@@ -16,6 +22,7 @@ axiosRetry(api, {
   },
 });
 
+/** Normalized error shape produced by the response interceptor below. */
 export interface ApiError {
   message: string;
   status: number;
@@ -37,6 +44,7 @@ api.interceptors.response.use(
   }
 );
 
+/** Generic cursor-paginated response envelope used by list endpoints. */
 export interface PaginatedResponse<T> {
   data: T[];
   nextCursor: string | null;
@@ -44,9 +52,24 @@ export interface PaginatedResponse<T> {
 }
 
 // Medical Records
+
+/**
+ * Fetch all medical records for a patient.
+ * @param patientAddress - Patient's wallet address.
+ * @returns Array of {@link MedicalRecord}.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const fetchRecords = (patientAddress: string) =>
   api.get<MedicalRecord[]>('/records', { params: { patientAddress } }).then((r) => r.data);
 
+/**
+ * Fetch a patient's medical records with cursor-based pagination.
+ * @param patientAddress - Patient's wallet address.
+ * @param cursor - Opaque cursor from a previous page's `nextCursor`; omit for the first page.
+ * @param limit - Max records per page (default 10).
+ * @returns {@link PaginatedResponse} of {@link MedicalRecord}.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const fetchRecordsPaginated = (patientAddress: string, cursor?: string, limit = 10) =>
   api
     .get<PaginatedResponse<MedicalRecord>>('/records', {
@@ -54,10 +77,25 @@ export const fetchRecordsPaginated = (patientAddress: string, cursor?: string, l
     })
     .then((r) => r.data);
 
+/**
+ * Share a medical record with another provider.
+ * @param recordId - ID of the record to share.
+ * @param providerAddress - Wallet address of the receiving provider.
+ * @returns The generated {@link ShareToken}.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const shareRecord = (recordId: string, providerAddress: string) =>
   api.post<ShareToken>(`/records/${recordId}/share`, { providerAddress }).then((r) => r.data);
 
 // Doctors & Slots
+
+/**
+ * Fetch the list of doctors, optionally filtered by specialty.
+ * @param specialty - Optional specialty filter.
+ * @param signal - Optional {@link AbortSignal} to cancel the request.
+ * @returns Array of {@link Doctor}.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const fetchDoctors = (specialty?: string, signal?: AbortSignal) =>
   api
     .get<Doctor[]>('/doctors', {
@@ -66,6 +104,14 @@ export const fetchDoctors = (specialty?: string, signal?: AbortSignal) =>
     })
     .then((r) => r.data);
 
+/**
+ * Fetch a doctor's patients with cursor-based pagination.
+ * @param doctorAddress - Doctor's wallet address.
+ * @param cursor - Opaque cursor from a previous page's `nextCursor`; omit for the first page.
+ * @param limit - Max patients per page (default 10).
+ * @returns {@link PaginatedResponse} of patient summary records.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const fetchDoctorPatientsPaginated = (doctorAddress: string, cursor?: string, limit = 10) =>
   api
     .get<
@@ -83,29 +129,73 @@ export const fetchDoctorPatientsPaginated = (doctorAddress: string, cursor?: str
     })
     .then((r) => r.data);
 
+/**
+ * Fetch available appointment slots for a doctor.
+ * @param doctorId - Doctor's ID.
+ * @returns Array of {@link TimeSlot}.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const fetchSlots = (doctorId: string) =>
   api.get<TimeSlot[]>(`/doctors/${doctorId}/slots`).then((r) => r.data);
 
 // Appointments
+
+/**
+ * Fetch appointments for a patient or doctor.
+ * @param address - Wallet address of the patient or doctor.
+ * @param role - Whether `address` identifies a `'patient'` or `'doctor'`.
+ * @returns Array of {@link Appointment}.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const fetchAppointments = (address: string, role: 'patient' | 'doctor') =>
   api.get<Appointment[]>('/appointments', { params: { address, role } }).then((r) => r.data);
 
+/**
+ * Create a new appointment.
+ * @param payload - Appointment fields, excluding server-assigned `id`, `status`, and `txHash`.
+ * @returns The created {@link Appointment}.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const createAppointment = (payload: Omit<Appointment, 'id' | 'status' | 'txHash'>) =>
   api.post<Appointment>('/appointments', payload).then((r) => r.data);
 
+/**
+ * Cancel an appointment.
+ * @param id - Appointment ID.
+ * @returns The updated {@link Appointment}.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const cancelAppointment = (id: string) =>
   api.patch<Appointment>(`/appointments/${id}/cancel`).then((r) => r.data);
 
+/**
+ * Update an appointment's status.
+ * @param id - Appointment ID.
+ * @param status - New status value.
+ * @returns The updated {@link Appointment}.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const updateAppointmentStatus = (id: string, status: Appointment['status']) =>
   api.patch<Appointment>(`/appointments/${id}/status`, { status }).then((r) => r.data);
 
-// Doctor — create medical record
+/**
+ * Create a new medical record (doctor-initiated).
+ * @param payload - New record fields; see {@link NewRecordPayload}.
+ * @returns The created {@link MedicalRecord}.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const createRecord = (payload: NewRecordPayload) =>
   api.post<MedicalRecord>('/records', payload).then((r) => r.data);
 
 export default api;
 
-// Encrypted record upload
+/**
+ * Upload an encrypted medical record.
+ * @param formData - Multipart form data containing the encrypted payload; sent with
+ *   `Content-Type: multipart/form-data`, overriding the instance default.
+ * @returns The stored {@link EncryptedRecord}.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const uploadEncryptedRecord = (formData: FormData) =>
   api
     .post<EncryptedRecord>('/records/encrypted', formData, {
@@ -114,30 +204,69 @@ export const uploadEncryptedRecord = (formData: FormData) =>
     .then((r) => r.data);
 
 // Hospital — metrics, staff, admissions, compliance
+
+/**
+ * Fetch aggregate metrics for a hospital.
+ * @param hospitalAddress - Hospital's wallet address.
+ * @returns {@link HospitalMetrics}.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const fetchHospitalMetrics = (hospitalAddress: string) =>
   api
     .get<HospitalMetrics>('/hospital/metrics', { params: { hospitalAddress } })
     .then((r) => r.data);
 
+/**
+ * Fetch a hospital's staff list.
+ * @param hospitalAddress - Hospital's wallet address.
+ * @returns Array of {@link StaffMember}.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const fetchStaff = (hospitalAddress: string) =>
   api.get<StaffMember[]>('/hospital/staff', { params: { hospitalAddress } }).then((r) => r.data);
 
+/**
+ * Fetch a hospital's current patient admissions.
+ * @param hospitalAddress - Hospital's wallet address.
+ * @returns Array of {@link PatientAdmission}.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const fetchAdmissions = (hospitalAddress: string) =>
   api
     .get<PatientAdmission[]>('/hospital/admissions', { params: { hospitalAddress } })
     .then((r) => r.data);
 
+/**
+ * Fetch compliance reports for a hospital.
+ * @param hospitalAddress - Hospital's wallet address.
+ * @returns Array of {@link ComplianceReport}.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const fetchComplianceReports = (hospitalAddress: string) =>
   api
     .get<ComplianceReport[]>('/hospital/compliance', { params: { hospitalAddress } })
     .then((r) => r.data);
 
+/**
+ * Apply a bulk action to a set of hospital staff members.
+ * @param hospitalAddress - Hospital's wallet address.
+ * @param staffIds - IDs of the staff members to update.
+ * @param action - Action to apply: `'activate'`, `'deactivate'`, or `'remove'`.
+ * @returns Server response payload for the bulk operation.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const bulkUpdateStaff = (
   hospitalAddress: string,
   staffIds: string[],
   action: 'activate' | 'deactivate' | 'remove',
 ) => api.post('/hospital/staff/bulk', { hospitalAddress, staffIds, action }).then((r) => r.data);
 
-// Bulk import medical records
+/**
+ * Bulk import medical records for a patient.
+ * @param patientAddress - Patient's wallet address.
+ * @param records - Rows to import; see {@link BulkRecordImportRow}.
+ * @returns {@link BulkImportResponse} summarizing successes/failures.
+ * @throws {ApiError} On network failure or non-2xx response.
+ */
 export const bulkImportRecords = (patientAddress: string, records: BulkRecordImportRow[]) =>
   api.post<BulkImportResponse>('/records/batch', { patientAddress, records }).then((r) => r.data);


### PR DESCRIPTION
## Summary
Adds JSDoc to every exported function in `src/services/api.service.ts` covering parameters, return type, and error behavior, plus documents the shared axios instance configuration.

## Changes
- JSDoc on all 17 exported functions (records, doctors/slots, appointments, hospital, bulk operations) describing params, `@returns`, and `@throws {ApiError}`
- JSDoc on the `api` axios instance documenting `baseURL` (from `NEXT_PUBLIC_API_URL`) and default headers
- JSDoc on `ApiError` and `PaginatedResponse<T>` interfaces
- No runtime logic changed — verified via diff that only comments/blank lines were added

## Context
`api.service.ts` is the app's entire API surface but had no JSDoc, forcing consumers to read implementation to know what each function expects/returns.

## Testing
Docs-only change (comments/blank lines only, confirmed via `git diff`). No behavior change; existing type signatures untouched.

Closes #81