### PR TITLE
docs: document src/lib/crypto.ts encryption/decryption approach

### DIFF
--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -2,18 +2,60 @@
  * Client-side AES-256-GCM encryption using the Web Crypto API.
  * Raw file bytes are encrypted before upload; only the content hash
  * and an encrypted metadata pointer are stored on-chain.
+ *
+ * ## Algorithm
+ * AES-256-GCM (authenticated encryption): a single `crypto.subtle.encrypt` call
+ * produces ciphertext with an integrity tag, so tampering with the encrypted
+ * blob is detectable on decryption rather than silently accepted.
+ *
+ * ## Key management
+ * - No password-based key derivation (e.g. PBKDF2/Argon2) is used. Each call to
+ *   {@link encryptFile} generates a fresh random 256-bit `CryptoKey` via
+ *   `crypto.subtle.generateKey`, scoped to a single file.
+ * - The key is generated as `extractable: true` so it can be exported and sent
+ *   to the backend (see {@link exportKey}). As currently wired up in
+ *   `MedicalRecordUpload.tsx`, the exported key is uploaded to the server in the
+ *   same request as the encrypted file — i.e. the server receives both the
+ *   ciphertext and the key needed to decrypt it. This scheme protects the file
+ *   in transit/at rest against anyone who does *not* have server access, but it
+ *   does **not** protect confidentiality from the backend/storage layer itself.
+ *   Any redesign to keep the server from ever seeing plaintext-equivalent
+ *   access would need out-of-band key custody (e.g. per-user/per-share keys
+ *   not transmitted alongside the ciphertext).
+ *
+ * ## IV handling
+ * A new 96-bit (12-byte) IV is generated per encryption via
+ * `crypto.getRandomValues`. 96 bits is the size recommended for AES-GCM.
+ * Reusing an IV with the same key would break GCM's confidentiality/integrity
+ * guarantees, but since {@link encryptFile} always pairs a fresh IV with a
+ * freshly generated key, reuse cannot occur here.
+ *
+ * ## Integrity hash
+ * {@link hashBuffer} computes a SHA-256 hex digest of the *ciphertext*, used as
+ * a content hash (e.g. for on-chain reference/dedup), not as a substitute for
+ * GCM's built-in authentication tag.
  */
 
+/**
+ * Encrypt a file's contents with a freshly generated AES-256-GCM key.
+ * @param file - File to encrypt.
+ * @returns The ciphertext (`encryptedBuffer`), the random 96-bit IV used, and
+ *   the extractable `CryptoKey` (export via {@link exportKey} if it needs to
+ *   leave the Web Crypto API, e.g. for upload).
+ */
 export async function encryptFile(file: File): Promise<{
   encryptedBuffer: ArrayBuffer;
   iv: Uint8Array;
   key: CryptoKey;
 }> {
+  // extractable: true — required so the key can be exported/uploaded (see module docs above)
   const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
     'encrypt',
     'decrypt',
   ]);
 
+  // 96-bit IV, the size recommended for AES-GCM; safe to reuse only because a new key
+  // is generated per call, so no (key, iv) pair is ever repeated.
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const fileBuffer = await file.arrayBuffer();
 
@@ -22,10 +64,23 @@ export async function encryptFile(file: File): Promise<{
   return { encryptedBuffer, iv, key };
 }
 
+/**
+ * Export a `CryptoKey` to a raw byte buffer so it can be transmitted or stored
+ * outside the Web Crypto API.
+ * @param key - An extractable AES-GCM `CryptoKey`, e.g. from {@link encryptFile}.
+ * @returns Raw key bytes.
+ */
 export async function exportKey(key: CryptoKey): Promise<ArrayBuffer> {
   return crypto.subtle.exportKey('raw', key);
 }
 
+/**
+ * Compute a SHA-256 hex digest of a buffer, used as a content-integrity hash
+ * (e.g. for the on-chain record pointer). This is independent of AES-GCM's own
+ * authentication tag, which already guards ciphertext integrity on decrypt.
+ * @param buffer - Bytes to hash (typically the encrypted file buffer).
+ * @returns Lowercase hex-encoded SHA-256 digest.
+ */
 export async function hashBuffer(buffer: ArrayBuffer): Promise<string> {
   const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
   return Array.from(new Uint8Array(hashBuffer))


### PR DESCRIPTION
## Summary
Documents the encryption scheme in `src/lib/crypto.ts` — algorithm, key generation/handling, IV handling, and integrity hashing — given the app's HIPAA-adjacent medical record data.

## Changes
- Module-level docblock covering:
  - Algorithm: AES-256-GCM (authenticated encryption)
  - Key management: no password-based derivation; fresh random 256-bit key per file; key is `extractable` and, per current usage in `MedicalRecordUpload.tsx`, is exported and uploaded to the server alongside the ciphertext — documented honestly as **not** protecting confidentiality from the backend/storage layer itself
  - IV handling: fresh 96-bit random IV per encryption, safe because it's always paired with a freshly generated key
  - Integrity: SHA-256 hash of ciphertext used as a content hash, separate from GCM's built-in auth tag
- JSDoc on `encryptFile`, `exportKey`, `hashBuffer` (params/returns)
- Inline comments explaining the non-obvious choices: `extractable: true`, and why IV reuse isn't a concern here

## Context
`crypto.ts` implements encryption for medical records but had no documentation of the algorithm, key management, or threat model — important given the sensitivity of the data. No cryptographic logic was changed (verified via diff — comments/docs only).

## Testing
Docs-only change. Confirmed via `git diff` that no executable lines were modified; traced actual key usage in `MedicalRecordUpload.tsx` to document real (not assumed) key-handling behavior.

Closes #82